### PR TITLE
Issue/javascript engine null

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM frolvlad/alpine-oraclejdk8:slim 
+FROM frolvlad/alpine-oraclejdk8:full
 
 # Install Leiningen 
 ENV LEIN_ROOT 1 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,8 @@ pipeline {
       }
       steps {
         withDockerRegistry([ credentialsId: "DOCKERHUB_PWD", url: "" ]) {
-          sh 'docker push interwaremx/alpine-lein-maven:1.0'
+          sh 'docker push interwaremx/alpine-lein-maven:1.1'
+          sh 'docker push interwaremx/alpine-lein-maven:latest'
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# alpine-lein-maven [ ![Build Status](http://ci.interware.mx:8080/jenkins/buildStatus/icon?job=alpine-lein-maven/master)](https://ci.interware.mx/jenkins/blue/organizations/jenkins/alpine-lein-mave/activity) [ ![](https://img.shields.io/badge/dockerhub-1.0-blue.svg?longCache=true&style=popout)](https://hub.docker.com/r/interwaremx/alpine-lein-maven/)
+# alpine-lein-maven [ ![Build Status](http://ci.interware.mx:8080/jenkins/buildStatus/icon?job=alpine-lein-maven/master)](https://ci.interware.mx/jenkins/blue/organizations/jenkins/alpine-lein-mave/activity) [ ![](https://img.shields.io/badge/dockerhub-1.1-blue.svg?longCache=true&style=popout)](https://hub.docker.com/r/interwaremx/alpine-lein-maven/)
 Minimal Java 8/Leiningen/Maven Docker Image built on Alpine Linux
 
 ### Alpine version
 ```
-$ docker container run --rm interwaremx/alpine-lein-maven:1.0 cat /etc/alpine-release
+$ docker container run --rm interwaremx/alpine-lein-maven:latest cat /etc/alpine-release
 3.8.0
 ```
 
 ### Java version
 ```
-$ docker container run --rm interwaremx/alpine-lein-maven:1.0 java -version
+$ docker container run --rm interwaremx/alpine-lein-maven:latest java -version
 java version "1.8.0_181"
 Java(TM) SE Runtime Environment (build 1.8.0_181-b13)
 Java HotSpot(TM) 64-Bit Server VM (build 25.181-b13, mixed mode)
@@ -17,13 +17,13 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.181-b13, mixed mode)
 
 ### Leiningen version
 ```
-$ docker container run --rm interwaremx/alpine-lein-maven:1.0 lein version
+$ docker container run --rm interwaremx/alpine-lein-maven:latest lein version
 Leiningen 2.8.1 on Java 1.8.0_181 Java HotSpot(TM) 64-Bit Server VM
 ```
 
 ### Maven version
 ```
-$ docker container run --rm interwaremx/alpine-lein-maven:1.0 mvn -v
+$ docker container run --rm interwaremx/alpine-lein-maven:latest mvn -v
 Apache Maven 3.5.3 (3383c37e1f9e9b3bc3df5050c29c8aff9f295297; 2018-02-24T19:49:05Z)
 Maven home: /usr/lib/mvn
 Java version: 1.8.0_181, vendor: Oracle Corporation

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-docker build -t interwaremx/alpine-lein-maven:1.0 .
+docker build -t interwaremx/alpine-lein-maven:1.1 .
+docker tag interwaremx/alpine-lein-maven:1.1 interwaremx/alpine-lein-maven:latest


### PR DESCRIPTION
lein-less and other clojurescript tools call factory javax.script.ScriptEngineManager to use NashornScriptEngine.

Using `1.0` factory returns nil
```
    $ docker run -ti interwaremx/alpine-lein-maven:1.0 lein repl
    Retrieving org/clojure/tools.nrepl/0.2.12/tools.nrepl-0.2.12.pom from central
    Retrieving org/clojure/pom.contrib/0.1.2/pom.contrib-0.1.2.pom from central
    Retrieving org/sonatype/oss/oss-parent/7/oss-parent-7.pom from central
    Retrieving clojure-complete/clojure-complete/0.2.4/clojure-complete-0.2.4.pom from clojars
    Retrieving org/clojure/tools.nrepl/0.2.12/tools.nrepl-0.2.12.jar from central
    Retrieving clojure-complete/clojure-complete/0.2.4/clojure-complete-0.2.4.jar from clojars
    nREPL server started on port 39231 on host 127.0.0.1 - nrepl://127.0.0.1:39231
    REPL-y 0.3.7, nREPL 0.2.12
    Clojure 1.8.0
    Java HotSpot(TM) 64-Bit Server VM 1.8.0_181-b13
        Docs: (doc function-name-here)
              (find-doc "part-of-name-here")
      Source: (source function-name-here)
     Javadoc: (javadoc java-object-or-class-here)
        Exit: Control+D or (exit) or (quit)
     Results: Stored in vars *1, *2, *3, an exception in *e

    user=> (-> (javax.script.ScriptEngineManager.) (.getEngineByName "javascript"))
    nil
```

This version `1.1` fix this behavior
```
    $ docker run -ti interwaremx/alpine-lein-maven:1.1 lein repl
    Retrieving org/clojure/tools.nrepl/0.2.12/tools.nrepl-0.2.12.pom from central
    Retrieving org/clojure/pom.contrib/0.1.2/pom.contrib-0.1.2.pom from central
    Retrieving org/sonatype/oss/oss-parent/7/oss-parent-7.pom from central
    Retrieving clojure-complete/clojure-complete/0.2.4/clojure-complete-0.2.4.pom from clojars
    Retrieving org/clojure/tools.nrepl/0.2.12/tools.nrepl-0.2.12.jar from central
    Retrieving clojure-complete/clojure-complete/0.2.4/clojure-complete-0.2.4.jar from clojars
    nREPL server started on port 45713 on host 127.0.0.1 - nrepl://127.0.0.1:45713
    REPL-y 0.3.7, nREPL 0.2.12
    Clojure 1.8.0
    Java HotSpot(TM) 64-Bit Server VM 1.8.0_181-b13
        Docs: (doc function-name-here)
              (find-doc "part-of-name-here")
      Source: (source function-name-here)
     Javadoc: (javadoc java-object-or-class-here)
        Exit: Control+D or (exit) or (quit)
     Results: Stored in vars *1, *2, *3, an exception in *e

    user=> (-> (javax.script.ScriptEngineManager.) (.getEngineByName "javascript"))
```